### PR TITLE
Using SPADes for hybrid assembly

### DIFF
--- a/config/template_config.yaml
+++ b/config/template_config.yaml
@@ -29,6 +29,7 @@ assembly:
     - metaspades
   long_read_assembler:
     - metaflye
+    - hybridspades
   # MEGAHIT configuration
   megahit:
     threads: 4
@@ -39,6 +40,9 @@ assembly:
   metaflye:
     threads: 4
     method: nanopore # or "pacbio"
+  hybridspades:
+    threads: 4
+    memory_limit: 50 # in GB
 
 ################################################################################
 #                               Assembly quality                               #

--- a/workflow/rules/03_assembly_LR.smk
+++ b/workflow/rules/03_assembly_LR.smk
@@ -24,3 +24,35 @@ rule metaflye_assembly:
         && \
         pigz {params.out_dir}/assembly.fa
         """
+
+# hybrid assembly using hybridSPADes
+rule hybridspades_assembly:
+    input:
+        r1 = "results/02_preprocess/bowtie2/{sample}_1.clean.fastq.gz",
+        r2 = "results/02_preprocess/bowtie2/{sample}_2.clean.fastq.gz",
+        long_read = "results/02_preprocess/fastp_long_read/{sample}_1.fastq.gz"
+    output:
+        assembly = "results/03_assembly/LR/hybridspades/{sample}/assembly.fa.gz"
+    conda:
+        "../envs/spades.yaml"
+    log:
+        stdout = "logs/03_assembly/hybridspades/{sample}.stdout",
+        stderr = "logs/03_assembly/hybridspades/{sample}.stdout"
+    params:
+        out_dir = "results/03_assembly/LR/hybridspades/{sample}",
+        memory_limit = config['assembly']['hybridspades']['memory_limit'],
+        method_flag = "--nanopore" if config['assembly']['metaflye']['method'] == "nanopore" else "--pacbio"
+    threads: config['assembly']['hybridspades']['threads']
+    shell:
+        """
+        spades.py --meta -1 {input.r1} -2 {input.r2} \
+            {params.method_flag} {input.long_read} \
+            --threads {threads} \
+            -o {params.out_dir} \
+            -m {params.memory_limit} \
+            > {log.stdout} 2> {log.stderr} \
+        && \
+        mv {params.out_dir}/scaffolds.fasta {params.out_dir}/assembly.fa \
+        && \
+        pigz {params.out_dir}/assembly.fa
+        """

--- a/workflow/scripts/merge_checkm2_reports.py
+++ b/workflow/scripts/merge_checkm2_reports.py
@@ -18,6 +18,10 @@ def identify_assembly_program(report_path: str):
         return 'metaspades'
     elif 'megahit' in report_path:
         return 'megahit'
+    elif 'metaflye' in report_path:
+        return 'metaflye'
+    elif 'hybridspades' in report_path:
+        return 'hybridspades'
     else:
         return None
     


### PR DESCRIPTION
Added a rule to use metaSPADes to assembly reads using both short and long reads.

https://ablab.github.io/spades/running.html#-meta-same-as-metaspadespy