### PR TITLE
Filtering out short contigs based on configuration

### DIFF
--- a/config/template_config.yaml
+++ b/config/template_config.yaml
@@ -34,16 +34,20 @@ assembly:
   # MEGAHIT configuration
   megahit:
     threads: 4
+    min_contig_len: 500 # minimal contig length to be kept in the produced assembly
   # SPAdes configuration
   metaspades:
     threads: 4
     memory_limit: 50 # in GB
+    min_contig_len: 500 # minimal contig length to be kept in the produced assembly
   metaflye:
     threads: 4
     method: nanopore # or "pacbio"
+    min_contig_len: 500 # minimal contig length to be kept in the produced assembly
   hybridspades:
     threads: 4
     memory_limit: 50 # in GB
+    min_contig_len: 500 # minimal contig length to be kept in the produced assembly
 
 ################################################################################
 #                               Assembly quality                               #

--- a/workflow/rules/03_assembly_LR.smk
+++ b/workflow/rules/03_assembly_LR.smk
@@ -12,7 +12,8 @@ rule metaflye_assembly:
         stderr = "logs/03_assembly/metaflye/{sample}.stderr"
     params:
         out_dir = "results/03_assembly/LR/metaflye/{sample}",
-        method_flag = "--nano-hq" if config['assembly']['metaflye']['method'] == "nanopore" else "--pacbio-hifi"
+        method_flag = "--nano-hq" if config['assembly']['metaflye']['method'] == "nanopore" else "--pacbio-hifi",
+        min_contig_len = config['assembly']['metaflye']['min_contig_len']
     threads: config['assembly']['metaflye']['threads']
     shell:
         """
@@ -22,5 +23,9 @@ rule metaflye_assembly:
         && \
         mv {params.out_dir}/assembly.fasta {params.out_dir}/assembly.fa \
         && \
-        pigz {params.out_dir}/assembly.fa
+        pigz {params.out_dir}/assembly.fa \
+        && \
+        seqkit seq -m {params.min_contig_len} {output.assembly} > tmp_assembly.fa.gz \
+        && \
+        mv tmp_assembly.fa.gz {output.assembly}
         """


### PR DESCRIPTION
With this PR users will have the possibility to filter out too short contigs in produced assemblies. To do so, the user should configure the `min_contig_len` fields in his YAML config.