### PR TITLE
Thread option was not passed to Checkm coverage rule

### DIFF
--- a/workflow/rules/08_bins_postprocessing.smk
+++ b/workflow/rules/08_bins_postprocessing.smk
@@ -293,6 +293,7 @@ rule coverage_in_mapping:
         """
         checkm coverage -x fa {input.dereplicated_and_filtered_bins} {output} \
             {input.samples_mapped_on_dereplicated_and_filtered_bins} \
+            --threads {threads} \
             > {log.stdout} 2> {log.stderr}
         """
 


### PR DESCRIPTION
`thread` option is set but it was not passed to `coverage_in_mapping` rule.